### PR TITLE
Avoid allocations in NetworkedAnimator

### DIFF
--- a/MLAPI/MonoBehaviours/Prototyping/NetworkedAnimator.cs
+++ b/MLAPI/MonoBehaviours/Prototyping/NetworkedAnimator.cs
@@ -245,12 +245,13 @@ namespace MLAPI
 
         void WriteParameters(BinaryWriter writer, bool autoSend)
         {
-            for (int i = 0; i < m_Animator.parameters.Length; i++)
+            AnimatorControllerParameter[] parameters = m_Animator.parameters;
+            for (int i = 0; i < parameters.Length; i++)
             {
                 if (autoSend && !GetParameterAutoSend(i))
                     continue;
 
-                AnimatorControllerParameter par = m_Animator.parameters[i];
+                AnimatorControllerParameter par = parameters[i];
                 if (par.type == AnimatorControllerParameterType.Int)
                 {
                     writer.Write((uint)m_Animator.GetInteger(par.nameHash));
@@ -276,12 +277,13 @@ namespace MLAPI
 
         void ReadParameters(BinaryReader reader, bool autoSend)
         {
-            for (int i = 0; i < m_Animator.parameters.Length; i++)
+            AnimatorControllerParameter[] parameters = m_Animator.parameters;
+            for (int i = 0; i < parameters.Length; i++)
             {
                 if (autoSend && !GetParameterAutoSend(i))
                     continue;
 
-                AnimatorControllerParameter par = m_Animator.parameters[i];
+                AnimatorControllerParameter par = parameters[i];
                 if (par.type == AnimatorControllerParameterType.Int)
                 {
                     int newValue = (int)reader.ReadUInt32();

--- a/MLAPI/MonoBehaviours/Prototyping/NetworkedAnimator.cs
+++ b/MLAPI/MonoBehaviours/Prototyping/NetworkedAnimator.cs
@@ -22,7 +22,6 @@ namespace MLAPI
             set
             {
                 m_Animator = value;
-                m_AnimatorParameters = m_Animator.parameters;
                 ResetParameterOptions();
             }
         }
@@ -75,6 +74,7 @@ namespace MLAPI
         {
             Debug.Log("ResetParameterOptions");
             m_ParameterSendBits = 0;
+            m_AnimatorParameters = null;
         }
 
         void FixedUpdate()
@@ -248,6 +248,7 @@ namespace MLAPI
 
         void WriteParameters(BinaryWriter writer, bool autoSend)
         {
+            if (m_AnimatorParameters == null) m_AnimatorParameters = m_Animator.parameters;
             for (int i = 0; i < m_AnimatorParameters.Length; i++)
             {
                 if (autoSend && !GetParameterAutoSend(i))
@@ -278,7 +279,8 @@ namespace MLAPI
         }
 
         void ReadParameters(BinaryReader reader, bool autoSend)
-        {     
+        {
+            if (m_AnimatorParameters == null) m_AnimatorParameters = m_Animator.parameters;
             for (int i = 0; i < m_AnimatorParameters.Length; i++)
             {
                 if (autoSend && !GetParameterAutoSend(i))
@@ -336,6 +338,16 @@ namespace MLAPI
                     }
                 }
             }
+        }
+
+        public override void OnGainedOwnership()
+        {
+            ResetParameterOptions();
+        }
+
+        public override void OnLostOwnership()
+        {
+            ResetParameterOptions();
         }
     }
 }

--- a/MLAPI/MonoBehaviours/Prototyping/NetworkedAnimator.cs
+++ b/MLAPI/MonoBehaviours/Prototyping/NetworkedAnimator.cs
@@ -339,15 +339,5 @@ namespace MLAPI
                 }
             }
         }
-
-        public override void OnGainedOwnership()
-        {
-            ResetParameterOptions();
-        }
-
-        public override void OnLostOwnership()
-        {
-            ResetParameterOptions();
-        }
     }
 }

--- a/MLAPI/MonoBehaviours/Prototyping/NetworkedAnimator.cs
+++ b/MLAPI/MonoBehaviours/Prototyping/NetworkedAnimator.cs
@@ -13,6 +13,8 @@ namespace MLAPI
         [SerializeField] uint       m_ParameterSendBits;
         [SerializeField] float m_SendRate = 0.1f;
 
+        AnimatorControllerParameter[] m_AnimatorParameters;
+
         // properties
         public Animator animator
         {
@@ -20,6 +22,7 @@ namespace MLAPI
             set
             {
                 m_Animator = value;
+                m_AnimatorParameters = m_Animator.parameters;
                 ResetParameterOptions();
             }
         }
@@ -245,13 +248,12 @@ namespace MLAPI
 
         void WriteParameters(BinaryWriter writer, bool autoSend)
         {
-            AnimatorControllerParameter[] parameters = m_Animator.parameters;
-            for (int i = 0; i < parameters.Length; i++)
+            for (int i = 0; i < m_AnimatorParameters.Length; i++)
             {
                 if (autoSend && !GetParameterAutoSend(i))
                     continue;
 
-                AnimatorControllerParameter par = parameters[i];
+                AnimatorControllerParameter par = m_AnimatorParameters[i];
                 if (par.type == AnimatorControllerParameterType.Int)
                 {
                     writer.Write((uint)m_Animator.GetInteger(par.nameHash));
@@ -276,14 +278,13 @@ namespace MLAPI
         }
 
         void ReadParameters(BinaryReader reader, bool autoSend)
-        {
-            AnimatorControllerParameter[] parameters = m_Animator.parameters;
-            for (int i = 0; i < parameters.Length; i++)
+        {     
+            for (int i = 0; i < m_AnimatorParameters.Length; i++)
             {
                 if (autoSend && !GetParameterAutoSend(i))
                     continue;
 
-                AnimatorControllerParameter par = parameters[i];
+                AnimatorControllerParameter par = m_AnimatorParameters[i];
                 if (par.type == AnimatorControllerParameterType.Int)
                 {
                     int newValue = (int)reader.ReadUInt32();


### PR DESCRIPTION
Replicate HLAPI patch in https://bitbucket.org/Unity-Technologies/networking/pull-requests/21/cache-animator-parameters-to-avoid/diff