### PR TITLE
Fix a bug that made NetworkedManager be set to null when destroying a…

### DIFF
--- a/MLAPI/MonoBehaviours/Core/NetworkingManager.cs
+++ b/MLAPI/MonoBehaviours/Core/NetworkingManager.cs
@@ -148,6 +148,10 @@ namespace MLAPI.MonoBehaviours.Core
         /// The callback to invoke once the server is ready
         /// </summary>
         public Action OnServerStarted = null;
+        /// <summary>
+        /// Wheter or not this NetworkedManager is an multiple instance of the singleton about to be removed.
+        /// </summary>
+        private bool isMultipleInstance = false;
         public delegate void ConnectionApprovedDelegate(uint clientId, int prefabId, bool approved, Vector3 position, Quaternion rotation);
         /// <summary>
         /// The callback to invoke during connection approval
@@ -646,7 +650,8 @@ namespace MLAPI.MonoBehaviours.Core
             if (singleton != null)
             {
                 if (LogHelper.CurrentLogLevel <= LogLevel.Normal) LogHelper.LogWarning("Multiple NetworkingManagers");
-                Destroy(this);
+                this.isMultipleInstance = true;
+                Destroy(this.gameObject);
                 return;
             }
             _singleton = this;
@@ -658,8 +663,10 @@ namespace MLAPI.MonoBehaviours.Core
         
         private void OnDestroy()
         {
-            _singleton = null;
-            Shutdown();
+            if (!isMultipleInstance) {
+                _singleton = null;
+                Shutdown();
+            }
         }
 
         private void Shutdown()


### PR DESCRIPTION
…nother multiple instance of the networked manager. Also change from removing only the component of the multiple instance to removing the whole gameobject.