### PR TITLE
Move the setting of ownerClientId in spawnManager to run before Invok…

### DIFF
--- a/MLAPI/NetworkingManagerComponents/Core/SpawnManager.cs
+++ b/MLAPI/NetworkingManagerComponents/Core/SpawnManager.cs
@@ -307,14 +307,16 @@ namespace MLAPI.NetworkingManagerComponents.Core
             spawnedObjects.Add(netId, netObject);
             netObject._isSpawned = true;
             netObject.sceneObject = false;
-            if (payload == null) netObject.InvokeBehaviourNetworkSpawn(null);
-            else using (BitReader payloadReader = BitReader.Get(payload.Finalize())) netObject.InvokeBehaviourNetworkSpawn(payloadReader);    
 
             if (clientOwnerId != null)
             {
                 netObject.ownerClientId = clientOwnerId.Value;
                 NetworkingManager.singleton.connectedClients[clientOwnerId.Value].OwnedObjects.Add(netObject);
             }
+
+            if (payload == null) netObject.InvokeBehaviourNetworkSpawn(null);
+            else using (BitReader payloadReader = BitReader.Get(payload.Finalize())) netObject.InvokeBehaviourNetworkSpawn(payloadReader);    
+
             foreach (var client in netManager.connectedClients)
             {
                 netObject.RebuildObservers(client.Key);


### PR DESCRIPTION
…eBehaviourNetworkSpawn.

ownerClientId was set after NetworkStart was invoked. I changed so it is set before invoking NetworkStart so that you can check isOwner inside the NetworkStart method.